### PR TITLE
Add #[bitmap_attr] macro - issue #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,29 @@ assert_eq!(player.finished_tasks(), 5);
 assert_eq!(player.kills(), 3);
 assert_eq!(*player, 0b01101011);
 ```
+## `#[bitmap_attr]` Attribute Macro
+
+If you prefer attribute macro syntax, you can use `#[bitmap_attr]` instead of `bitmap!`. Both work exactly the same way.
+
+```rust
+use bitmap::bitmap_attr;
+
+#[bitmap_attr]
+struct Player {
+    imposter: u1,
+    finished_tasks: u3,
+    kills: u3,
+}
+
+let mut player = Player(0);
+player.set_imposter(1)
+    .set_finished_tasks(5)
+    .set_kills(3);
+
+assert_eq!(player.imposter(), 1);
+assert_eq!(player.finished_tasks(), 5);
+assert_eq!(player.kills(), 3);
+}
 
 ### Accessing fields
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -133,10 +133,8 @@ pub fn bitmap(input: TokenStream) -> TokenStream {
 pub fn bitmap_attr(_args: TokenStream, input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     
-    // Converting the attribute macro input to the existing BitmapInput format
     let bitmap_input = convert_derive_to_bitmap_input(input);
     
-    // Use the EXACT SAME expansion logic as the bitmap! macro
     match generator::expand_bitmap(bitmap_input) {
         Ok(tokens) => tokens.into(),
         Err(err) => err.to_compile_error().into(),
@@ -146,7 +144,6 @@ pub fn bitmap_attr(_args: TokenStream, input: TokenStream) -> TokenStream {
 fn convert_derive_to_bitmap_input(input: DeriveInput) -> parser::BitmapInput {
     let name = input.ident;  
     
-    // Extracting struct fields
     let syn::Data::Struct(data_struct) = input.data else {
         panic!("#[bitmap_attr] can only be used on structs");
     };
@@ -155,12 +152,10 @@ fn convert_derive_to_bitmap_input(input: DeriveInput) -> parser::BitmapInput {
         panic!("#[bitmap_attr] struct must have named fields");
     };
     
-    // Converting each field to the format expected by the existing parser
     let fields = fields_named.named.into_iter().map(|field| {
         let field_name = field.ident.expect("Field must have a name");
         let field_type = field.ty;
         
-        // Extracting the size from the type (e.g., u1 -> 1, u7 -> 7)
         let type_str = field_type.to_token_stream().to_string();
         
         if !type_str.starts_with("u") {

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,8 +1,6 @@
 use proc_macro::TokenStream;
 use syn::parse_macro_input;
-use syn::DeriveInput;  
-      
-use quote::ToTokens;  
+use syn::DeriveInput;
 
 mod generator;
 mod parser;
@@ -156,7 +154,6 @@ pub fn bitmap(input: TokenStream) -> TokenStream {
 /// assert_eq!(player.kills(), 3);
 /// assert_eq!(*player, 0b01101011);
 /// ```
-
 #[proc_macro_attribute]
 pub fn bitmap_attr(_args: TokenStream, input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,7 +1,7 @@
 use proc_macro::TokenStream;
 use syn::parse_macro_input;
 use syn::DeriveInput;  
-use quote::quote;      
+      
 use quote::ToTokens;  
 
 mod generator;
@@ -133,7 +133,7 @@ pub fn bitmap(input: TokenStream) -> TokenStream {
 pub fn bitmap_attr(_args: TokenStream, input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     
-    // Convert the attribute macro input to the existing BitmapInput format
+    // Converting the attribute macro input to the existing BitmapInput format
     let bitmap_input = convert_derive_to_bitmap_input(input);
     
     // Use the EXACT SAME expansion logic as the bitmap! macro
@@ -144,9 +144,9 @@ pub fn bitmap_attr(_args: TokenStream, input: TokenStream) -> TokenStream {
 }
 
 fn convert_derive_to_bitmap_input(input: DeriveInput) -> parser::BitmapInput {
-    let name = input.ident;  // Use 'name' not 'struct_name'
+    let name = input.ident;  
     
-    // Extract struct fields
+    // Extracting struct fields
     let syn::Data::Struct(data_struct) = input.data else {
         panic!("#[bitmap_attr] can only be used on structs");
     };
@@ -155,12 +155,12 @@ fn convert_derive_to_bitmap_input(input: DeriveInput) -> parser::BitmapInput {
         panic!("#[bitmap_attr] struct must have named fields");
     };
     
-    // Convert each field to the format expected by the existing parser
+    // Converting each field to the format expected by the existing parser
     let fields = fields_named.named.into_iter().map(|field| {
         let field_name = field.ident.expect("Field must have a name");
         let field_type = field.ty;
         
-        // Extract the size from the type (e.g., u1 -> 1, u7 -> 7)
+        // Extracting the size from the type (e.g., u1 -> 1, u7 -> 7)
         let type_str = field_type.to_token_stream().to_string();
         
         if !type_str.starts_with("u") {
@@ -180,7 +180,7 @@ fn convert_derive_to_bitmap_input(input: DeriveInput) -> parser::BitmapInput {
     }).collect();
     
     parser::BitmapInput {
-        name,  // Use 'name' not 'struct_name'
+        name,  
         fields,
     }
 }

--- a/macros/src/parser.rs
+++ b/macros/src/parser.rs
@@ -49,3 +49,16 @@ impl Parse for FieldDef {
         Ok(FieldDef { name, size })
     }
 }
+
+pub fn parse_bit_width(ty: &syn::Ident) -> Result<u8> {
+    let ty_str = ty.to_string();
+    if !ty_str.starts_with("u") {
+        return Err(syn::Error::new_spanned(ty, format!("Invalid type {ty_str}, expected u{{1..128}}")));
+    }
+    let size = ty_str[1..].parse::<u8>()
+        .map_err(|e| syn::Error::new_spanned(ty, format!("Could not parse type size: {e}")))?;
+    if size == 0 || size > 128 {
+        return Err(syn::Error::new_spanned(ty, format!("Invalid size for {ty_str}, expected u{{1..128}}")));
+    }
+    Ok(size)
+}

--- a/macros/src/parser.rs
+++ b/macros/src/parser.rs
@@ -33,18 +33,7 @@ impl Parse for FieldDef {
         let _: Token![:] = input.parse()?;
         let ty: Ident = input.parse()?;
 
-        let ty_str = ty.to_string();
-        let ty_str = ty_str.as_str();
-        if !ty_str.starts_with("u") {
-            return Err(syn::Error::new_spanned(ty, format!("Invalid type {ty_str}, expected u{{1..128}}")));
-        }
-        let size = *match &ty_str[1..].parse::<u8>() {
-            Ok(val) => val,
-            Err(e) => return Err(syn::Error::new_spanned(ty, format!("Could not parse type size: {e}"))),
-        };
-        if size == 0 || size > 128 {
-            return Err(syn::Error::new_spanned(ty, format!("Invalid size for {ty_str}, expected u{{1..128}}")));
-        }
+        let size = parse_bit_width(&ty)?;
 
         Ok(FieldDef { name, size })
     }
@@ -55,7 +44,8 @@ pub fn parse_bit_width(ty: &syn::Ident) -> Result<u8> {
     if !ty_str.starts_with("u") {
         return Err(syn::Error::new_spanned(ty, format!("Invalid type {ty_str}, expected u{{1..128}}")));
     }
-    let size = ty_str[1..].parse::<u8>()
+    let size = ty_str[1..]
+        .parse::<u8>()
         .map_err(|e| syn::Error::new_spanned(ty, format!("Could not parse type size: {e}")))?;
     if size == 0 || size > 128 {
         return Err(syn::Error::new_spanned(ty, format!("Invalid size for {ty_str}, expected u{{1..128}}")));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
 #![no_std]
 
 pub use macros::bitmap;
+pub use macros::bitmap_attr;  
 pub use traits::*;
+
 
 pub mod traits;
 

--- a/tests/compare_macros.rs
+++ b/tests/compare_macros.rs
@@ -1,6 +1,5 @@
 use bitmap::{bitmap, bitmap_attr};
 
-// Function-like macro (original)
 bitmap!(
     struct OldWay {
         flag: u1,
@@ -8,7 +7,6 @@ bitmap!(
     }
 );
 
-// Attribute macro (new)
 #[bitmap_attr]
 struct NewWay {
     flag: u1, 
@@ -20,11 +18,9 @@ fn test_both_macros_produce_same_api() {
     let mut old = OldWay(0);
     let mut new = NewWay(0);
     
-    // Both should have the same methods
     old.set_flag(1).set_counter(42);
     new.set_flag(1).set_counter(42);
     
-    // Both should produce the same results
     assert_eq!(old.flag(), new.flag());
     assert_eq!(old.counter(), new.counter());
     assert_eq!(*old, *new);

--- a/tests/compare_macros.rs
+++ b/tests/compare_macros.rs
@@ -1,0 +1,34 @@
+// tests/compare_macros.rs
+use bitmap::{bitmap, bitmap_attr};
+
+// Function-like macro (original)
+bitmap!(
+    struct OldWay {
+        flag: u1,
+        counter: u7,
+    }
+);
+
+// Attribute macro (new)
+#[bitmap_attr]
+struct NewWay {
+    flag: u1, 
+    counter: u7,
+}
+
+#[test]
+fn test_both_macros_produce_same_api() {
+    let mut old = OldWay(0);
+    let mut new = NewWay(0);
+    
+    // Both should have the same methods
+    old.set_flag(1).set_counter(42);
+    new.set_flag(1).set_counter(42);
+    
+    // Both should produce the same results
+    assert_eq!(old.flag(), new.flag());
+    assert_eq!(old.counter(), new.counter());
+    assert_eq!(*old, *new);
+    
+    println!("Both macros produce identical results!");
+}

--- a/tests/compare_macros.rs
+++ b/tests/compare_macros.rs
@@ -1,4 +1,3 @@
-// tests/compare_macros.rs
 use bitmap::{bitmap, bitmap_attr};
 
 // Function-like macro (original)

--- a/tests/test_attr.rs
+++ b/tests/test_attr.rs
@@ -1,4 +1,3 @@
-// tests/test_attr.rs
 use bitmap::bitmap_attr;
 
 #[bitmap_attr]
@@ -11,15 +10,15 @@ struct TestBits {
 fn test_attribute_macro_creates_correct_api() {
     let mut bits = TestBits(0);
     
-    // Test that the macro generated the correct methods
+    // Testing that the macro generated the correct methods
     bits.set_flag(1);
     bits.set_counter(42);
     
     assert_eq!(bits.flag(), 1);
     assert_eq!(bits.counter(), 42);
     
-    // Test the raw value
-    assert_eq!(*bits, 0b10101010); // flag=1 (MSB), counter=42
+    // Testing the raw value
+    assert_eq!(*bits, 0b10101010); 
     
     println!("Attribute macro creates correct bitmap API!");
 }

--- a/tests/test_attr.rs
+++ b/tests/test_attr.rs
@@ -1,0 +1,33 @@
+// tests/test_attr.rs
+use bitmap::bitmap_attr;
+
+#[bitmap_attr]
+struct TestBits {
+    flag: u1,
+    counter: u7,
+}
+
+#[test]
+fn test_attribute_macro_creates_correct_api() {
+    let mut bits = TestBits(0);
+    
+    // Test that the macro generated the correct methods
+    bits.set_flag(1);
+    bits.set_counter(42);
+    
+    assert_eq!(bits.flag(), 1);
+    assert_eq!(bits.counter(), 42);
+    
+    // Test the raw value
+    assert_eq!(*bits, 0b10101010); // flag=1 (MSB), counter=42
+    
+    println!("Attribute macro creates correct bitmap API!");
+}
+
+#[test] 
+fn test_attribute_macro_deref_and_into() {
+    let bits = TestBits(0xFF);
+    let raw_value: u8 = bits.into();
+    assert_eq!(raw_value, 0xFF);
+    assert_eq!(*bits, 0xFF);
+}

--- a/tests/test_attr.rs
+++ b/tests/test_attr.rs
@@ -10,14 +10,12 @@ struct TestBits {
 fn test_attribute_macro_creates_correct_api() {
     let mut bits = TestBits(0);
     
-    // Testing that the macro generated the correct methods
     bits.set_flag(1);
     bits.set_counter(42);
     
     assert_eq!(bits.flag(), 1);
     assert_eq!(bits.counter(), 42);
     
-    // Testing the raw value
     assert_eq!(*bits, 0b10101010); 
     
     println!("Attribute macro creates correct bitmap API!");


### PR DESCRIPTION
This adds the attribute macro from issue #8. 

Now you can do:

```rust
#[bitmap_attr]
struct Bits {
    flag: u1,
    counter: u7,
}
```

Instead of:

```rust
bitmap!(
    struct Bits {
        flag: u1,
        counter: u7,
    }
);
```

Both ways work the same and make the same struct with the same methods. The tests show they work identically.

Fixes #8

